### PR TITLE
Fix exception on GetAlarm

### DIFF
--- a/source/nanoFramework.Hardware.Stm32/RTC.cs
+++ b/source/nanoFramework.Hardware.Stm32/RTC.cs
@@ -39,7 +39,7 @@ namespace nanoFramework.Hardware.Stm32
         public static DateTime GetAlarm()
         {
             long alarmTicks = Native_RTC_GetAlarm();
-            return new DateTime(alarmTicks, DateTimeKind.Utc);
+            return new DateTime(alarmTicks);
         }
 
         #region native methods calls


### PR DESCRIPTION
## Description
- Remove call to method setting the DateTimeKind as all DateTimes in nF are already in UTC.

## Motivation and Context
- Fixes nanoFramework/Home#437.

## How Has This Been Tested?<!-- (if applicable) -->
- SMT32 sample.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
